### PR TITLE
Fixed checkstyle errors in algorithms, arrays, and basics folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@ _site/
 *.nav
 *.snm
 *.vrb
+=======
+#ide files
+*.idea
+*.iml
+
+
+#os files
+*.directory

--- a/code/algorithms/Fac.java
+++ b/code/algorithms/Fac.java
@@ -2,9 +2,9 @@ public class Fac {
 
     public static void main(String[] args) {
         int n = Integer.parseInt(args[0]);
-        System.out.println("facLoop("+n+")=" + facLoop(n));
-        System.out.println("facTail("+n+")=" + facTail(n));
-        System.out.println("fac("+n+")=" + fac(n));
+        System.out.println("facLoop(" + n + ")=" + facLoop(n));
+        System.out.println("facTail(" + n + ")=" + facTail(n));
+        System.out.println("fac(" + n + ")=" + fac(n));
     }
 
     /**

--- a/code/algorithms/GtStudent.java
+++ b/code/algorithms/GtStudent.java
@@ -7,9 +7,13 @@ public class GtStudent {
         name = aName;
         major = aMajor;
     }
-    public String getName() { return name; }
+    public String getName() {
+        return name;
+    }
 
-    public Major getMajor() { return major; }
+    public Major getMajor() {
+        return major;
+    }
 
     public String toString() {
         return name + " (" + major + ")";

--- a/code/algorithms/InsertionSort.java
+++ b/code/algorithms/InsertionSort.java
@@ -9,7 +9,7 @@ public class InsertionSort {
             assert isSorted(a, 0, j - 1);
             int key = a[j];
             int i = j - 1;
-            while(i >= 0 && a[i] < key) {
+            while (i >= 0 && a[i] < key) {
                 a[i + 1] = a[i];
                 i = i - 1;
             }

--- a/code/algorithms/Search.java
+++ b/code/algorithms/Search.java
@@ -1,12 +1,17 @@
-import java.time.*;
-import java.util.*;
-import java.util.stream.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Search {
 
     public static int linearSearch(Integer[] array, Integer value) {
         for (int i = 0; i < array.length; i++) {
-            if (array[i] == value) { return i; }
+            if (array[i] == value) {
+                return i;
+            }
         }
         return -1;
     }
@@ -14,7 +19,7 @@ public class Search {
     public static int binarySearchLoop(Integer[] array, int queryValue) {
         int lo = 0, hi = array.length - 1;
         while (lo <= hi) {
-            int middle = (lo + hi)/2;
+            int middle = (lo + hi) / 2;
             if (array[middle] == queryValue) {
                 return middle;
             }
@@ -31,11 +36,12 @@ public class Search {
         return bsHelper(array, queryValue, 0, array.length - 1);
     }
 
-    private static int bsHelper(Integer[] array, int queryValue, int lo, int hi) {
+    private static int bsHelper(Integer[] array, int queryValue,
+            int lo, int hi) {
         if (lo > hi) {
             return -1;
         }
-        int middle = (lo + hi)/2;
+        int middle = (lo + hi) / 2;
         if (queryValue == array[middle]) {
             return middle;
         } else if (queryValue > array[middle]) {
@@ -49,7 +55,7 @@ public class Search {
                                       Comparator<? super T> c) {
         int lo = 0, hi = array.length - 1;
         while (lo <= hi) {
-            int middle = (lo + hi)/2;
+            int middle = (lo + hi) / 2;
             if (c.compare(array[middle], queryValue) == 0) {
                 return middle;
             }

--- a/code/algorithms/Sort.java
+++ b/code/algorithms/Sort.java
@@ -10,7 +10,7 @@ public class Sort {
             assert isSorted(a, 0, j - 1);
             T key = a[j];
             int i = j - 1;
-            while(i >= 0 && (a[i].compareTo(key) > 0)) {
+            while (i >= 0 && (a[i].compareTo(key) > 0)) {
                 a[i + 1] = a[i];
                 i = i - 1;
             }
@@ -21,8 +21,9 @@ public class Sort {
     private static <T extends Comparable<? super T>>
             boolean isSorted(T[] array, int start, int end) {
         for (int i = start; i < end; ++i) {
-            if (!(array[i].compareTo(array[i + 1]) < 0))
+            if (!(array[i].compareTo(array[i + 1]) < 0)) {
                 return false;
+            }
         }
         return true;
     }
@@ -63,7 +64,9 @@ public class Sort {
 
     // Why isn't something like this in Arrays, like Collections.shuffle()?
     public static <T> void shuffle(T[] array) {
-        if (random == null) { random = new Random(); }
+        if (random == null) {
+            random = new Random();
+        }
         int count = array.length;
         for (int i = count; i > 1; i--) {
             swap(array, i - 1, random.nextInt(i));

--- a/code/arrays/ArrayBasics.java
+++ b/code/arrays/ArrayBasics.java
@@ -1,7 +1,7 @@
 import java.util.Arrays;
 
 public class ArrayBasics {
-    
+
     class Dog {
         public void speak() {
             System.out.println("Woof, woof!");
@@ -21,7 +21,9 @@ public class ArrayBasics {
 
     public static String arrayToString(double[] a) {
         StringBuilder sb = new StringBuilder();
-        for (double e: a) sb.append(e + " ");
+        for (double e: a) {
+            sb.append(e + " ");
+        }
         return sb.toString();
     }
 
@@ -36,7 +38,7 @@ public class ArrayBasics {
         }
         return sb.toString();
     }
-    
+
 
     public static void main(String[] args) {
         double[] scores = new double[5];
@@ -76,7 +78,7 @@ public class ArrayBasics {
         for (int i = 0; i < scores.length; ++i) {
             System.out.printf("scores[%d] = %.2f%n", i, scores[i]);
         }
-        
+
         // System.out.println("Trying scores[scores.length] = 100 causes:");
         // scores[scores.length] = 100;
 

--- a/code/arrays/CourseAverage.java
+++ b/code/arrays/CourseAverage.java
@@ -10,7 +10,7 @@ public class CourseAverage {
         Scanner gradeFile = null;
         try {
             gradeFile = new Scanner(new FileInputStream("grades.txt"));
-        } catch(FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             System.out.println(e.getMessage());
             System.exit(0);
         }

--- a/code/arrays/GradeBook.java
+++ b/code/arrays/GradeBook.java
@@ -6,7 +6,7 @@ public class GradeBook {
     public GradeBook() {
         this(10);
     }
-    
+
     public GradeBook(int capacity) {
         scores = new int[capacity];
         lastScore = 0;

--- a/code/arrays/GradeBookDriver.java
+++ b/code/arrays/GradeBookDriver.java
@@ -8,13 +8,17 @@ public class GradeBookDriver {
         gradeBook.modifyScore(1, 84);
         // Now scores are 80, 84, 92
         System.out.println("GradeBook scores are:");
-        for (int score: gradeBook.getScores()) System.out.println(score);
+        for (int score: gradeBook.getScores()) {
+            System.out.println(score);
+        }
         // Privacy leak: now we have a local reference to a private variable:
         int[] myReferenceToScores = gradeBook.getScores();
         // We can use our local reference to update the private instance var:
         myReferenceToScores[0] = 100;
         // Now scores are 100, 84, 92:
         System.out.println("GradeBook scores are:");
-        for (int score: gradeBook.getScores()) System.out.println(score);
+        for (int score: gradeBook.getScores()) {
+            System.out.println(score);
+        }
     }
 }

--- a/code/arrays/MarkovChain.java
+++ b/code/arrays/MarkovChain.java
@@ -1,7 +1,9 @@
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Scanner;
 
 public class MarkovChain {
 
@@ -18,7 +20,7 @@ public class MarkovChain {
 
 
     private void train(Collection<String> trainingFiles)
-            throws FileNotFoundException{
+            throws FileNotFoundException {
         for (String source: trainingFiles) {
             FileInputStream fis =
                 new FileInputStream(new File(source + ".corpus"));
@@ -38,7 +40,7 @@ public class MarkovChain {
         int[] charIndexes = string2CharIndexes(sentence);
         for (int i = 0; i < charIndexes.length - 1; ++i) {
             int row = charIndexes[i];
-            int col = charIndexes[i+1];
+            int col = charIndexes[i + 1];
             // Increment the count of char[i+1] following char[i]
             freqs[row][col] = freqs[row][col] + 1;
         }

--- a/code/arrays/PartialIntArray.java
+++ b/code/arrays/PartialIntArray.java
@@ -9,26 +9,27 @@ public class PartialIntArray {
     }
 
     public PartialIntArray(int initialCapacity) {
-        if (initialCapacity < 0)
-            throw new IllegalArgumentException("Illegal Capacity: "+
-                                               initialCapacity);
-        this.elements = new int[initialCapacity];
+        if (initialCapacity < 0) {
+            throw new IllegalArgumentException("Illegal Capacity: "
+                    + initialCapacity);
+            this.elements = new int[initialCapacity];
+        }
     }
 
     public void add(int e) {
         if (size >= elements.length) {
             int[] resizedArray = new int[elements.length * 2];
             for (int i = 0; i < elements.length; i++) {
-                
+                //TODO add code here!
             }
         }
-        
+
         elements[size++] = e;
     }
 
     public int get(int index) {
         if (index < 0 || index >= size) {
-            // ...
+            //TODO add code here!
         }
         return elements[index];
     }

--- a/code/arrays/PartialIntArray.java
+++ b/code/arrays/PartialIntArray.java
@@ -12,8 +12,8 @@ public class PartialIntArray {
         if (initialCapacity < 0) {
             throw new IllegalArgumentException("Illegal Capacity: "
                     + initialCapacity);
-            this.elements = new int[initialCapacity];
         }
+        this.elements = new int[initialCapacity];
     }
 
     public void add(int e) {

--- a/code/arrays/Shout.java
+++ b/code/arrays/Shout.java
@@ -5,7 +5,7 @@ public class Shout {
         for (int i = 0; i < args.length; i++) {
             System.out.println("args[" + i + "] = " + args[i]);
         }
-        
+
         System.out.println("Now I'm gonna shout them to you:");
         for (String arg: args) {
             System.out.print(arg.toUpperCase() + " ");

--- a/code/arrays/VarArgs.java
+++ b/code/arrays/VarArgs.java
@@ -3,14 +3,16 @@ public class VarArgs {
     public static int max(int ... numbers) {
         int max = numbers[0];
         for (int i = 1; i < numbers.length; ++i) {
-            if (numbers[i] > max) max = numbers[i];
+            if (numbers[i] > max) {
+                max = numbers[i];
+            }
         }
         return max;
     }
 
     public static void main(String ... args) {
         int topScore = max(92, 87, 56, 97, 89, 98);
-        int [] nums = { 24, 45, 67, 789};
+        int [] nums = {24, 45, 67, 789};
         int topNum = max(nums);
         System.out.printf("Tops score is %d%n", topScore);
     }

--- a/code/basics/ArrayFun.java
+++ b/code/basics/ArrayFun.java
@@ -2,9 +2,9 @@ public class ArrayFun {
 
     public static void main(String[] args) {
         for (int i = 0; i < args.length; ++i) {
-            System.out.println("args["+i+"]="+ args[i]);
+            System.out.println("args[" + i + "]=" + args[i]);
         }
-        double scores[] = {99, 56, 78, 99, 45};
+        double[] scores = {99, 56, 78, 99, 45};
         for (int i = 0; i < scores.length; ++i) {
             System.out.println(scores[i]);
         }

--- a/code/basics/Bugs.java
+++ b/code/basics/Bugs.java
@@ -11,10 +11,10 @@ public class Bugs {
     public static void main(String[] args) {
         // If no command line arguments, what is args.length?
         email = args[0];
-        
+
         // What if email not assigned a value after initialization?
         int len = email.length();
-        
+
         // What if email, an aribitrary String, is not a valid email address?
         sendEmail("Hi!", email);
     }

--- a/code/basics/Bugs2.java
+++ b/code/basics/Bugs2.java
@@ -8,14 +8,14 @@ public class Bugs {
             System.out.println("Need command line args.");
             System.exit(0);
         }
-        
+
         // If no command line arguments, what is args.length?
         //email = args[0];
-        
-        
+
+
         // What if email not assigned a value after initialization?
         int len = email.length();
-        
+
         // What if email, an aribitrary String, is not a valid email address?
         boolean isEmailValid =
             (email.endsWith(".com")
@@ -34,7 +34,9 @@ public class Bugs {
         boolean containsAt = false;
         // Can you spot the bugs here before we run the program?
         for (int i = 0; i <= s.length(); i++) {
-            if (s.substring(i, i) == "@") containsAt = true;
+            if (s.substring(i, i) == "@") {
+                containsAt = true;
+            }
             // What if @ is early in the string?
         }
         return containsAt;

--- a/code/basics/CharCountSwitch.java
+++ b/code/basics/CharCountSwitch.java
@@ -10,34 +10,34 @@ public class CharCountSwitch {
         int digitCount = 0, punctuationCount = 0, letterCount = 0;
         for (int i = 0; i < s.length(); ++i) {
             switch (s.charAt(i)) {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                    // Fall-through matches all digits
-                    digitCount++;
-                    break;
-                case '!':
-                case '?':
-                case '.':
-                    // Fall-through matches all punctuation
-                    punctuationCount++;
-                    break;
-                default:
-                    // Others are assumed to be letters
-                    letterCount++;
-                    // break is optional after the default case
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                // Fall-through matches all digits
+                digitCount++;
+                break;
+            case '!':
+            case '?':
+            case '.':
+                // Fall-through matches all punctuation
+                punctuationCount++;
+                break;
+            default:
+                // Others are assumed to be letters
+                letterCount++;
+                // break is optional after the default case
             }
             // Will the code above provide an accurate count of letters?
         }
         System.out.printf("Your input contained %d digits, %d "
-                          + "punctuaion marks, and %d letters.%n",
-                          digitCount, punctuationCount, letterCount);
+                + "punctuaion marks, and %d letters.%n",
+                digitCount, punctuationCount, letterCount);
     }
 }

--- a/code/basics/Conditionals.java
+++ b/code/basics/Conditionals.java
@@ -1,16 +1,17 @@
 import java.util.Scanner;
 
 public class Conditionals {
-    
+
     public static void main(String[] args) {
         System.out.print("Enter an integer: ");
         Scanner keyboard = new Scanner(System.in);
         int num = keyboard.nextInt();
 
-        if ((num % 2) == 0)
+        if ((num % 2) == 0) {
             System.out.printf("%d is even.%n", num);
-        else
+        } else {
             System.out.printf("%d is odd.%n", num);
+        }
 
         // Boolean expressions
         boolean numIsEven = (num % 2) == 0;

--- a/code/basics/ConsoleIO.java
+++ b/code/basics/ConsoleIO.java
@@ -6,6 +6,6 @@ public class ConsoleIO {
         console.printf("Gimme input: ----- ");
         String input = console.readLine();
         System.out.println("input=" + input);
-        
+
     }
 }

--- a/code/basics/CourseGrade.java
+++ b/code/basics/CourseGrade.java
@@ -11,10 +11,15 @@ public class CourseGrade {
             + (.2 * finalExam);
         System.out.println("Course Average: " + courseAverage);
         char grade = 'F';
-        if (courseAverage >= 90) grade = 'A';
-        else if (courseAverage >= 80) grade = 'B';
-        else if (courseAverage >= 70) grade = 'C';
-        else if (courseAverage >= 60) grade = 'D';
+        if (courseAverage >= 90) {
+            grade = 'A';
+        } else if (courseAverage >= 80) {
+            grade = 'B';
+        } else if (courseAverage >= 70) {
+            grade = 'C';
+        } else if (courseAverage >= 60) {
+            grade = 'D';
+        }
         System.out.println("Course Grade: " + grade);
     }
 }

--- a/code/basics/CurrencyFormatting.java
+++ b/code/basics/CurrencyFormatting.java
@@ -2,7 +2,7 @@ import java.text.NumberFormat;
 import java.util.Locale;
 
 public class CurrencyFormatting {
-    
+
     public static void main(String[] args) {
         NumberFormat us = NumberFormat.getCurrencyInstance();
         System.out.println(us.format(3.14));

--- a/code/basics/Loops.java
+++ b/code/basics/Loops.java
@@ -3,27 +3,32 @@ public class Loops {
     public static void main(String[] args) {
         boolean shouldContinue = true;
         while (shouldContinue) {
-            System.out.println("Enter a string of alphanumeric characters" +
-                               " (exit to quit):");
+            System.out.println("Enter a string of alphanumeric characters"
+                    + " (exit to quit):");
             String input = System.console().readLine();
             int digitCount = 0, letterCount = 0;
             for (int i = 0; i < input.length(); ++i) {
                 char c = input.charAt(i);
-                if (Character.isDigit(c)) digitCount++;
-                if (Character.isAlphabetic(c)) letterCount++;
+                if (Character.isDigit(c)) {
+                    digitCount++;
+                }
+                if (Character.isAlphabetic(c)) {
+                    letterCount++;
+                }
             }
             System.out.printf("Input contained %d digits and %d letters.%n",
-                              digitCount, letterCount);
+                    digitCount, letterCount);
             shouldContinue = (input.equalsIgnoreCase("exit")) ? false : true;
         }
 
-        for (int i = 0; i < 10; ++i)
+        for (int i = 0; i < 10; ++i) {
             System.out.println("Meow!");
+        }
 
         String mystery = "mnerigpaba";
         String solved = "";
         int len = mystery.length();
-        for (int i = 0, j = len - 1; i < len/2; ++i, --j) {
+        for (int i = 0, j = len - 1; i < len / 2; ++i, --j) {
             solved = solved + mystery.charAt(i) + mystery.charAt(j);
         }
         System.out.println(solved);
@@ -32,11 +37,11 @@ public class Loops {
         // you'll have to use Ctrl-C to stop the program.
 
         //for (;;) {
-            // ever
+        // ever
         //}
 
         // while (true} {
         //     // forever
         // }
-   }
+    }
 }

--- a/code/basics/ShortCircuit.java
+++ b/code/basics/ShortCircuit.java
@@ -1,13 +1,13 @@
 public class ShortCircuit {
 
     private static int counter = 0;
-    
+
     private static boolean incrementCounter() {
         counter++;
         return true;
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         boolean a = true;
         boolean b = false;
         if (a || incrementCounter()) {

--- a/code/basics/Strings.java
+++ b/code/basics/Strings.java
@@ -28,10 +28,11 @@ public class Strings {
         int bPos = bam.indexOf("b");
         System.out.println("In bam, \"b\" first occurs at index " + bPos);
 
-        System.out.println("bam.substring(3, 6)= \""+bam.substring(3, 6)+"\"");
+        System.out.println("bam.substring(3, 6)= \""
+                + bam.substring(3, 6) + "\"");
 
         System.out.println("\"a\".compareTo(\"z\")" + "returns "
-        + "a".compareTo("z"));
+                + "a".compareTo("z"));
 
 
         // The empty String is just that:


### PR DESCRIPTION
I don't know why the switch statement indentation was considered incorrect by checkstyle, perhaps that's a problem with the cs1331 xml file. If that is fixed, I will update this pull request.

I used the latest checkstyle and xml file found in this repo

Some checkstyle errors remain intentionally, as they are part of a lesson (ie: missing for loop code (to be filled during lecture), variable a must be private (in a static variables lesson)).

There are some compiler errors in 'basic' but those existed before and are probably intentional.