### PR TITLE
Fixing broken links html->pdfs

### DIFF
--- a/fall2015.html
+++ b/fall2015.html
@@ -63,7 +63,7 @@ title: CS 1331 - Fall 2015
 
     <tr>
       <td>2015-08-17</td>
-      <td><a href="slides/intro-cs1331.html">Introduction</a></td>
+      <td><a href="slides/introduction.pdf">Introduction</a></td>
       <td>
         Lecture notes: <a href="lecture-notes/intro-cs1331.pdf">intro-cs1331.pdf</a><br/>
         Tutorial: Getting Started -
@@ -75,7 +75,7 @@ title: CS 1331 - Fall 2015
 
     <tr>
       <td>2015-08-19</td>
-      <td><a href="slides/values-variables.html">Values and Variables</a></td>
+      <td><a href="slides/values-variables.pdf">Values and Variables</a></td>
       <td>
         Lecture notes: <a href="lecture-notes/values-variables.pdf">Values and Variables</a><br/>
 
@@ -99,7 +99,7 @@ title: CS 1331 - Fall 2015
     <tr>
       <td>2015-08-24</td>
       <td>
-        <a href="slides/programs-methods.html">Programs and Methods</a><br/>
+        <a href="slides/programs-methods.pdf">Programs and Methods</a><br/>
         <br/>
         <a href="slides/basic-io.pdf">Basic IO</a> (Recitation)
       </td>


### PR DESCRIPTION
## Purpose
First three links to the schedule lectures were broken because they were switched to .html with no corresponding files.

I changed introduction, values and variables, and program methods.

-Julia