### PR TITLE
Updated cs1331.org urls to cs1331.github.io

### DIFF
--- a/_includes/CS1331.md
+++ b/_includes/CS1331.md
@@ -82,7 +82,7 @@ At least one of:
 
 * Required software: Java 8 SDK, available from [Oracle](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html)
 * Official textbook: Introduction to Java Programming, Comprehensive Version, 10th Edition by Y. Daniel Liang, ISBN-10: 0133761312, ISBN-13: 978-0133761313
-* Course websites: all course materials will be on the public web site at [http://cs1331.org](http://cs1331.org). All student grade information will be on the course's T-Square site.
+* Course websites: all course materials will be on the public web site at [http://cs1331.github.io](http://cs1331.github.io). All student grade information will be on the course's T-Square site.
 
 Note that the textbook is useful, but not required. We provide extensive lecture notes, example code, and programming exercises on the course web site.
 

--- a/lecture-notes/intro-cs1331.tex
+++ b/lecture-notes/intro-cs1331.tex
@@ -68,7 +68,7 @@ missing from C++) greatly reduces software development effort.
 \section{The Java SDK}
 
 \vspace{-.05in}
-Follow the instructions on the \href{http://cs1331.org/resources.html}{Resources} page of the course web site to install the JDK. Installing the JDK on your computer provides you with several command-line tools, the most important of which are:
+Follow the instructions on the \href{http://cs1331.github.io/resources.html}{Resources} page of the course web site to install the JDK. Installing the JDK on your computer provides you with several command-line tools, the most important of which are:
 
 \begin{itemize}
 \item {\tt javac} - the Java compiler, which compiles {\tt .java} files to {\tt .class} files.  You can tell you have correctly installed your SDK like this:

--- a/slides/introduction.tex
+++ b/slides/introduction.tex
@@ -115,7 +115,7 @@ missing from C++) greatly reduces software development effort.
 \begin{frame}[fragile]{The Java SDK}
 
 \vspace{-.05in}
-Follow the instructions on the \link{http://cs1331.org/resources.html}{Resources} page of the course web site to install the JDK. Installing the JDK on your computer provides you with several command-line tools, the most important of which are:
+Follow the instructions on the \link{http://cs1331.github.io/resources.html}{Resources} page of the course web site to install the JDK. Installing the JDK on your computer provides you with several command-line tools, the most important of which are:
 
 \begin{itemize}
 \item {\tt javac} - the Java compiler, which compiles {\tt .java} files to {\tt .class} files.  You can tell you have correctly installed your SDK like this:


### PR DESCRIPTION
There's one "cs1331.org" left in beamer-common.tex but I don't know where it should redirect