### PR TITLE
Fix typo for files we need

### DIFF
--- a/fall2016/hw2/hw2.md
+++ b/fall2016/hw2/hw2.md
@@ -239,7 +239,7 @@ In order to submit your assignment you need to ensure that your working code is 
 
 You should have the following in your repository:
 
-* `Civilization.java`
+* `CivilizationGame.java`
 * `CoalMine.java`
 * `Treasury.java`
 * `Game.java`


### PR DESCRIPTION
We're supposed to remove `Civilization.java` in favor of `CivilizationGame.java`, right?